### PR TITLE
fix(renovate): use default renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["github>kubewarden/github-actions//renovate-config/default"],
 }


### PR DESCRIPTION
## Description

Updates the load-testing renovate bot configuration to use the default file used by all the other major components of the Kubewarden stack. Thus, patch versions bumps will be automatically merged by the bot.
